### PR TITLE
Ordenar dúvidas por votos

### DIFF
--- a/forum_amo/views.py
+++ b/forum_amo/views.py
@@ -41,7 +41,7 @@ class DuvidaViewSet(AccessViewSetMixin, ModelViewSet):
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = DuvidaFilter
     search_fields = ["titulo"]
-    ordering_fields = ["data"]
+    ordering_fields = ["data", "votos"]
     ordering = ["data"]
 
     @action(methods=["POST", "DELETE"], detail=True)


### PR DESCRIPTION
Possibilita ordenar dúvidas por votos.

Exemplo: Ordenar por votos de forma ascendente.
`http://127.0.0.1:8000/duvidas/?ordering=votos`